### PR TITLE
Filter non-ruby files from list passed to reek

### DIFF
--- a/lib/pronto/reek.rb
+++ b/lib/pronto/reek.rb
@@ -8,6 +8,7 @@ module Pronto
 
       patches_with_additions = patches.select { |patch| patch.additions > 0 }
       files = patches_with_additions.map { |patch| patch.new_file_full_path.to_s }
+      files = files.grep /\.rb$/
 
       if files.any?
         examiner = ::Reek::Examiner.new(files)

--- a/spec/pronto/reek_spec.rb
+++ b/spec/pronto/reek_spec.rb
@@ -17,6 +17,40 @@ module Pronto
         let(:patches) { [] }
         it { should == [] }
       end
+
+      context 'patches with additions' do
+        let(:patches) { [
+          double("patch with additions", additions: 4, new_file_full_path: 'ruby_code.rb'),
+          double("patch without additions", additions: 0) ] }
+
+        let(:examiner) { double("examiner", smells: []) }
+
+        before do
+          ::Reek::Examiner.stub(:new).and_return examiner
+        end
+
+        it "calls reek with the files that have additions" do
+          subject
+          ::Reek::Examiner.should have_received(:new).with ['ruby_code.rb']
+        end
+      end
+
+      context 'patches with additions to non-ruby files' do
+        let(:patches) { [
+          double("patch for ruby file", additions: 4, new_file_full_path: 'ruby_code.rb'),
+          double("patch for non-ruby file", additions: 4, new_file_full_path: 'other.stuff') ] }
+
+        let(:examiner) { double("examiner", smells: []) }
+
+        before do
+          ::Reek::Examiner.stub(:new).and_return examiner
+        end
+
+        it "calls reek with only the ruby files" do
+          subject
+          ::Reek::Examiner.should have_received(:new).with ['ruby_code.rb']
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Reek doesn't like files that are not parsable as Ruby.
