### PR TITLE
Use latest Pronto.

### DIFF
--- a/pronto-reek.gemspec
+++ b/pronto-reek.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'pronto', '~> 0.4.0'
-  s.add_dependency 'reek', '~> 1.4.0'
+  s.add_dependency 'reek', '~> 1.6.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'

--- a/pronto-reek.gemspec
+++ b/pronto-reek.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'pronto', '~> 0.3.0'
+  s.add_dependency 'pronto', '~> 0.4.0'
   s.add_dependency 'reek', '~> 1.4.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Current release gem depends on `~> 0.2.0`; should probably depend on `~> 0.2`.