### PR TITLE
Update reek dependency

### DIFF
--- a/pronto-reek.gemspec
+++ b/pronto-reek.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'pronto', '~> 0.4.0'
-  s.add_dependency 'reek', '~> 1.6.0'
+  s.add_dependency 'reek', '~> 2.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
Hi,

Reek 2 is out. This PR makes pronto-reek use it.