### PR TITLE
Update reek api use

### DIFF
--- a/lib/pronto/reek.rb
+++ b/lib/pronto/reek.rb
@@ -11,7 +11,7 @@ module Pronto
       files = patches_with_additions.map { |patch| patch.new_file_full_path.to_s }
 
       if files.any?
-        examiner = ::Reek::Examiner.new(files)
+        examiner = ::Reek::Core::Examiner.new(files)
         messages_for(patches_with_additions, examiner.smells).compact
       else
         []

--- a/pronto-reek.gemspec
+++ b/pronto-reek.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'pronto', '~> 0.4.0'
-  s.add_dependency 'reek', '~> 2.0'
+  s.add_dependency 'reek', '~> 2.2.1'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'

--- a/spec/pronto/reek_spec.rb
+++ b/spec/pronto/reek_spec.rb
@@ -19,7 +19,7 @@ module Pronto
       end
 
       let(:examiner) { double('examiner', smells: []) }
-      before { ::Reek::Examiner.stub(:new).and_return(examiner) }
+      before { ::Reek::Core::Examiner.stub(:new).and_return(examiner) }
 
       context 'patches with additions' do
         let(:patches) do
@@ -29,7 +29,7 @@ module Pronto
 
         it 'calls reek with the files that have additions' do
           subject
-          ::Reek::Examiner.should have_received(:new).with ['ruby_code.rb']
+          ::Reek::Core::Examiner.should have_received(:new).with ['ruby_code.rb']
         end
       end
 
@@ -43,7 +43,7 @@ module Pronto
 
         it 'calls reek with only the ruby files' do
           subject
-          ::Reek::Examiner.should have_received(:new).with ['ruby_code.rb']
+          ::Reek::Core::Examiner.should have_received(:new).with ['ruby_code.rb']
         end
       end
     end


### PR DESCRIPTION
Reek's Reek::Examiner class was moved to Reek::Core::Examiner in reek 2.2.0, causing pronto-reek to fail. This PR fixes this.

Note, reek's API for programmatic use hasn't really been defined yet, which is why this change was introduced in a minor release. We're hoping to have a well-defined and stable API in place in the 3.0 release.