### PR TITLE
Add link to documentation in the error messages

### DIFF
--- a/spec/pronto/reek_spec.rb
+++ b/spec/pronto/reek_spec.rb
@@ -21,16 +21,22 @@ module Pronto
         include_context 'test repo'
 
         let(:patches) { repo.diff('c04b312') }
+        let(:uncommunicate_parameter_link) do
+          'https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md'
+        end
+        let(:uncommunicate_variable_link) do
+          'https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md'
+        end
 
         its(:count) { should == 2 }
         its(:'first.msg') do
           should ==
-            "Has the parameter name 'n' (UncommunicativeParameterName)"
+            "Has the parameter name 'n' ([UncommunicativeParameterName](#{uncommunicate_parameter_link}))"
         end
 
         its(:'last.msg') do
           should ==
-            "Has the variable name '@n' (UncommunicativeVariableName)"
+            "Has the variable name '@n' ([UncommunicativeVariableName](#{uncommunicate_variable_link}))"
         end
       end
 


### PR DESCRIPTION
This PR changes each error message to contain a link to the corresponding
smell type documentation from [the Reek docs](https://github.com/troessner/reek/tree/master/docs).

Example:
```
app/controllers/posts_controller.rb:24 W: Has the name 'create2' ([UncommunicativeMethodName](https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md))
```

References issue: https://github.com/mmozuras/pronto-reek/issues/8