### PR TITLE
Change code smell message level to :info

### DIFF
--- a/lib/pronto/reek.rb
+++ b/lib/pronto/reek.rb
@@ -31,7 +31,7 @@ module Pronto
       path = line.patch.delta.new_file[:path]
       message = "#{error.message.capitalize} (#{error.smell_type})"
 
-      Message.new(path, line, :warning, message, nil, self.class)
+      Message.new(path, line, :info, message, nil, self.class)
     end
 
     def patch_for_error(error)


### PR DESCRIPTION
The motivation for this change is marking GitHub commit status as failed:
![screen shot 2016-05-11 at 16 31 19](https://cloud.githubusercontent.com/assets/249141/15184529/d71f10e6-1795-11e6-90cf-50f575cf3daa.png)

As [reek documentation](https://github.com/troessner/reek/blob/master/docs/Code-Smells.md#code-smells) says: 
> Smells are indicators of where your code might be hard to read, maintain or evolve, rather than things that are specifically _wrong_.

Therefor I think `:info` level is more appropriate than `:warning`.

@mmozuras What do you think?