### PR TITLE
Add reek config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@
 [![Dependency Status](https://gemnasium.com/mmozuras/pronto-reek.png)](https://gemnasium.com/mmozuras/pronto-reek)
 
 Pronto runner for [Reek](https://github.com/troessner/reek), code smell detector for Ruby. [What is Pronto?](https://github.com/mmozuras/pronto)
+
+## Configuration
+
+Configuring Reek via [config.reek](https://github.com/troessner/reek#configuration-file), or any file ending with .reek, will work just fine with pronto-reek.

--- a/lib/pronto/reek.rb
+++ b/lib/pronto/reek.rb
@@ -5,9 +5,10 @@ module Pronto
   class Reek < Runner
     def run
       files = ruby_patches.map(&:new_file_full_path)
+      configuration = ::Reek::Configuration::AppConfiguration.from_path
 
       smells = files.flat_map do |file|
-        ::Reek::Examiner.new(file).smells
+        ::Reek::Examiner.new(file, configuration: configuration).smells
       end
       messages_for(smells).compact
     end

--- a/spec/pronto/reek_spec.rb
+++ b/spec/pronto/reek_spec.rb
@@ -51,7 +51,7 @@ module Pronto
 
         it 'calls reek with only the ruby files' do
           subject
-          ::Reek::Examiner.should have_received(:new).with ruby_file
+          ::Reek::Examiner.should have_received(:new).with(ruby_file, hash_including(:configuration))
           ::Reek::Examiner.should_not have_received(:new).with other_file
         end
       end


### PR DESCRIPTION
Now its possible to use reek config file while running via pronto.